### PR TITLE
🇵🇪 Add Peru: community corpus by Crafter Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Legalize turns official legislation into version-controlled, machine-readable da
 | 🇬🇧 United Kingdom | [legalize-uk](https://github.com/legalize-dev/legalize-uk) | 3,970 | [legislation.gov.uk](https://www.legislation.gov.uk/) | ✅ Live |
 | 🇦🇩 Andorra | [legalize-ad](https://github.com/legalize-dev/legalize-ad) | 3,545 | [BOPA](https://www.bopa.ad/) | ✅ Live |
 | 🇱🇮 Liechtenstein | [legalize-li](https://github.com/legalize-dev/legalize-li) | 3,504 | [LiLex](https://www.gesetze.li/) | ✅ Live |
+| 🇵🇪 Peru | [legalize-pe](https://github.com/crafter-research/legalize-pe) | 1,617 | [SPIJ](https://spij.minjus.gob.pe/) | ✅ Community |
 | 🇪🇪 Estonia | [legalize-ee](https://github.com/legalize-dev/legalize-ee) | 1,597 | [Riigi Teataja](https://www.riigiteataja.ee/) | ✅ Live |
 | 🇳🇴 Norway | [legalize-no](https://github.com/legalize-dev/legalize-no) | 779 | [Lovdata](https://lovdata.no/) | ✅ Live |
 | 🇸🇰 Slovakia | [legalize-sk](https://github.com/legalize-dev/legalize-sk) | 300 | [Slov-Lex](https://www.slov-lex.sk/) | ✅ Live |
@@ -102,6 +103,7 @@ git diff 6660bcf^..6660bcf -- es/BOE-A-1978-31229.md
 | **[legalize-uk](https://github.com/legalize-dev/legalize-uk)** | UK legislation (3,970 acts). |
 | **[legalize-ad](https://github.com/legalize-dev/legalize-ad)** | Andorran laws (3,545 norms). |
 | **[legalize-li](https://github.com/legalize-dev/legalize-li)** | Liechtenstein laws (3,504 norms). |
+| **[legalize-pe](https://github.com/crafter-research/legalize-pe)** | Peruvian laws (1,617 norms). Community contribution by [Crafter Research](https://github.com/crafter-research). |
 | **[legalize-ee](https://github.com/legalize-dev/legalize-ee)** | Estonian laws (1,597 norms). |
 | **[legalize-no](https://github.com/legalize-dev/legalize-no)** | Norwegian laws (779 norms). |
 | **[legalize-sk](https://github.com/legalize-dev/legalize-sk)** | Slovak laws (300 norms). |


### PR DESCRIPTION
## 🇵🇪 Add Peru, community-maintained

Korea-pattern row in the README table + Repos section.

- **Corpus**: [`crafter-research/legalize-pe`](https://github.com/crafter-research/legalize-pe). 1,617 norms (Constitution 1993, 31 reformas, codes, DLeg, DS, RM) migrated to SPEC v0.2. Plus 5 Ordenanzas Regionales from Cusco (`pe-cus/`) as the sub-national pioneer.
- **Engine** (separate repo, public pre-1.0): [`crafter-research/legalize-pe-engine`](https://github.com/crafter-research/legalize-pe-engine). Bun + Turborepo + Astro.
- **Bot identity**: `Crafternauta <the.crafter.station@gmail.com>` on all corpus commits, with historical author dates (pre-1970 epoch hack handled).

**Data source** (3-layer cascade per jurisdiction): datos abiertos CSV catalog, SPIJ portal body, El Peruano gazette reforms. Public domain per DLeg 822 Art. 9.

**Why this matters**: Peru has 1,919 sub-national legal authorities (25 GR + Lima Metro + Callao + 196 provincial + 1,695 distrital munis). Cusco is V1; Tier 1 (27 regional) is the next milestone. First attempt at a cohesive sub-national legal corpus aggregation for a Global South country.

Not asking for `legalize-pipeline` integration since our stack is TS/Bun. Just the README row, same as @9bow's `legalize-kr`.

Maintainer: [@Railly](https://github.com/Railly) (Railly Hugo), [@shiarauzo](https://github.com/shiarauzo) (Shiara Arauzo),  [Crafter Research](https://github.com/crafter-research).